### PR TITLE
Preventing "Save" button from accidentally submitting form

### DIFF
--- a/hulk.js
+++ b/hulk.js
@@ -437,9 +437,10 @@
         }
         var html = convertJSONToHTML(data, options);
         var button = getSaveButton();
-        attachSaveHandler(button, function() {
+        attachSaveHandler(button, function(event) {
             var newData = reassembleJSON($element.children(), options);
             callback(newData);
+            event.preventDefault();
         });
         $element.html(html);
         $element.append(button);


### PR DESCRIPTION
If the hulk editor is included in a form with a submit action, pressing the button will submit the form, this is probably not intended (and if intended, is easily restored in the callback). This pull request prevents the submit action.
